### PR TITLE
small a11y improvements

### DIFF
--- a/src/Components/Nav.js
+++ b/src/Components/Nav.js
@@ -191,7 +191,7 @@ class Navigation extends Component {
                     <Col xs={12}>
                         <Nav>
                             <LogoWrapper to="/">
-                                <img src={Logo} width="70" alt="Logo" />
+                                <img src={Logo} width="70" alt="Home" />
                             </LogoWrapper>
                             <List>
                                 <Item>
@@ -226,6 +226,8 @@ class Navigation extends Component {
                                 </Item>
                                 <Item>
                                     <a
+                                        tabIndex="0"
+                                        role="button"
                                         className="active_nav"
                                         onClick={this.openModal}
                                     >

--- a/src/Components/Search.js
+++ b/src/Components/Search.js
@@ -112,6 +112,7 @@ class Search extends Component {
             <Query query={query}>
                 {({ data, client }) => (
                     <Wrapper
+                        role="search"
                         className={`${
                             this.state.focused ||
                             (data[keyName] && data[keyName].length)
@@ -135,7 +136,7 @@ class Search extends Component {
                             )}
                         {!data[keyName] &&
                             this.state.focused === false && (
-                                <SlashIcon>/</SlashIcon>
+                                <SlashIcon aria-hidden="true">/</SlashIcon>
                             )}
                         <Input
                             innerRef={node => (this.input = node)}

--- a/src/Pages/Favorites.js
+++ b/src/Pages/Favorites.js
@@ -9,8 +9,10 @@ import Nav from './../Components/Nav'
 
 export default () => (
     <Grid>
-        <Nav />
-        <Header title="Favorites" noSearch />
+        <div role="banner">
+            <Nav />
+            <Header title="Favorites" noSearch />
+        </div>
         <Row>
             <Col xs={12}>
                 <Query query={GET_FAVORITES}>

--- a/src/Pages/Home.js
+++ b/src/Pages/Home.js
@@ -26,8 +26,10 @@ export default () => (
             />
             <meta name="twitter:image:alt" content="awesome talks" />
         </Helmet>
-        <Nav />
-        <Header query={GET_SEARCH} keyName="search" />
+        <div role="banner">
+            <Nav />
+            <Header query={GET_SEARCH} keyName="search" />
+        </div>
         <Query query={GET_SEARCH}>
             {({ data: { search }, client }) => <Talks search={search} />}
         </Query>

--- a/src/Pages/Speaker.js
+++ b/src/Pages/Speaker.js
@@ -67,7 +67,6 @@ const Section = styled.div`
 
 const SpeakerInfo = ({ photo, name, bio, twitter }) => (
     <Wrapper>
-        <Nav />
         <Helmet>
             <title>Awesome Talks - {name}</title>
             <meta name="twitter:title" content={`Awesome Talks - ${name}`} />
@@ -82,6 +81,9 @@ const SpeakerInfo = ({ photo, name, bio, twitter }) => (
                 content={`Amazing Tech Talks by ${name}`}
             />
         </Helmet>
+        <div role="banner">
+            <Nav />
+        </div>
         <Desc>
             {photo ? (
                 <Img src={photo.url} alt={name} height="200" width="200" />

--- a/src/Pages/Speakers.js
+++ b/src/Pages/Speakers.js
@@ -24,7 +24,6 @@ const Wrapper = styled(Flex)`
 
 const Speakers = ({ data: { searchSpeakers } }) => (
     <Grid>
-        <Nav />
         <Helmet>
             <title>Awesome Talks - Speakers</title>
             <meta
@@ -42,11 +41,14 @@ const Speakers = ({ data: { searchSpeakers } }) => (
             />
             <meta name="twitter:image:alt" content="awesome talks" />
         </Helmet>{' '}
-        <Header
-            title="Speakers"
-            query={GET__SPEAKERS_SEARCH}
-            keyName="searchSpeakers"
-        />
+        <div role="banner">
+            <Nav />
+            <Header
+                title="Speakers"
+                query={GET__SPEAKERS_SEARCH}
+                keyName="searchSpeakers"
+            />
+        </div>
         <Row>
             <Col xs={12}>
                 <Query query={SPEAKERS}>

--- a/src/Pages/Tag.js
+++ b/src/Pages/Tag.js
@@ -14,7 +14,6 @@ export default ({
     }
 }) => (
     <Grid>
-        <Nav />
         <Helmet>
             <title>Awesome Talks - {category}</title>
             <meta
@@ -35,7 +34,10 @@ export default ({
             />
             <meta name="twitter:image:alt" content="awesome talks" />
         </Helmet>
-        <Header title={`#${humanize(category)}`} noSearch code />
+        <div role="banner">
+            <Nav />
+            <Header title={`#${humanize(category)}`} noSearch code />
+        </div>
         <Row>
             <Col xs={12}>
                 <Query

--- a/src/Pages/Tags.js
+++ b/src/Pages/Tags.js
@@ -11,7 +11,6 @@ const makeLink = name => `/category/${name.replace(/\s+/g, '-').toLowerCase()}`
 
 export default () => (
     <Grid>
-        <Nav />
         <Helmet>
             <title>Awesome Talks - Categories</title>
             <meta
@@ -29,7 +28,10 @@ export default () => (
             />
             <meta name="twitter:image:alt" content="awesome talks" />
         </Helmet>
-        <Header title="Categories" noSearch />
+        <div role="banner">
+            <Nav />
+            <Header title="Categories" noSearch />
+        </div>
         <Row>
             <Col xs={12}>
                 <Query query={TAGS}>


### PR DESCRIPTION
this PR adds the following a11y updates:
1. wrap the navigation and search components into a global banner landmark
2. change the logo alt text from “logo” to “home” as that’s a more meaningful announcement to its purpose.
3. the “add a talk” button was keyboard inaccessible, adding a role=“button” and tabIndex=“0” allows screen reader users to hear its intended role and access it with the tab key (another issue will be made about this element)
4. wrap the search component in a role=“search” to add it to the listing of landmarks in the application.  Add an aria-label to the input.