### PR TITLE
Updates the YT link for RSS feed

### DIFF
--- a/src/Utils/rss.js
+++ b/src/Utils/rss.js
@@ -41,7 +41,7 @@ export default client({ query })
             return feed.item({
                 title: name,
                 author: description,
-                url: `https://youtube.com?v=${link}`,
+                url: `https://youtube.com/watch?v=${link}`,
                 speaker: speaker.name,
                 categories: tags.map(({ name }) => name)
             })


### PR DESCRIPTION
The original link to a video that's published in the feed redirects to the YouTube's homepage. I've added a missing `/watch` segment to it.