### PR TITLE
Bug: Video duration should not depend on timezone.

### DIFF
--- a/src/Utils/youtube.js
+++ b/src/Utils/youtube.js
@@ -1,11 +1,17 @@
 import format from 'date-fns/format'
+import addMinutes from 'date-fns/add_minutes'
 
 export const getDuration = duration => {
-    var date = new Date(null)
+    const date = new Date(null)
     date.setSeconds(duration)
     if (duration > 3600) {
-        return format(date, 'H[h][ ]m[m]')
-    }
+    // We use addMinutes instead of subMinutes because 
+    // Date.prototype.getTimezoneOffset() returns negative number for positive offsets.
+    return format(
+      addMinutes(date, date.getTimezoneOffset()), 
+      'H[h][ ]m[m]'
+    )
+  }
 
     return format(date, 'm[m]')
 }


### PR DESCRIPTION
I am in GMT +01:00 so I get video duration to be for example 2h 7m instead 1h 7m.
Now, it is fixed.